### PR TITLE
Small change to practice Github Flow pull requests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def options_for_video_reviews(selected=nil)
-    options_for_select([1,2,3,4,5].map {|n| [pluralize(n, 'Star'), n]}, selected)
+    options_for_select((1..5).map {|n| [pluralize(n, 'Star'), n]}, selected)
   end
 end


### PR DESCRIPTION
Small change to practice Github Flow pull requests: `[1,2,3,4,5]` changed to `(1..5)`
